### PR TITLE
Tighten footer disclaimer and copyright copy

### DIFF
--- a/src/components/shared/Footer.tsx
+++ b/src/components/shared/Footer.tsx
@@ -7,11 +7,11 @@ const Footer = () => {
     <Container component="footer" size="xl" pt="xl" pb="xl">
       <Stack gap="sm">
         <Text size="sm" c="dimmed">
-          Disclaimer: The information provided on this page is as-is & not
-          financial advice.
+          Not financial advice — general educational information, provided
+          as-is.
         </Text>
         <Text size="sm" c="dimmed">
-          Copyright © 2023–{currentYear} Leo Hong ·{" "}
+          © 2023–{currentYear} Leo Hong · Source on{" "}
           <Anchor
             href="https://github.com/low-earth-orbit/personal-finance"
             target="_blank"


### PR DESCRIPTION
Copy cleanup to the shared site footer (shown under every tool and the hub).

- **Disclaimer** — lead with the key point; drop app-specific wording since this footer is generic (it also appears on the hub, which has no results):
  - before: _Disclaimer: The information provided on this page is as-is & not financial advice._
  - after: _Not financial advice — general educational information, provided as-is._
- **Copyright line** — remove the redundant "Copyright" before the © symbol, and label the GitHub link as the source repo it actually points to ("Source on GitHub").

No logic changes; the Footer test (`/not financial advice/i`) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)