### PR TITLE
Show consent modal on every route; expand its copy

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,5 +1,13 @@
 import { test, expect } from "@playwright/test";
 
+test.beforeEach(async ({ context }) => {
+  // The first-visit disclaimer modal now mounts on every route. Pre-accept it
+  // so its overlay doesn't sit over the app during these flows.
+  await context.addInitScript(() => {
+    window.localStorage.setItem("rvb_disclaimerAccepted", "true");
+  });
+});
+
 test("hub landing page lists the available tools", async ({ page }) => {
   await page.goto("/");
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,13 +12,7 @@ import {
 } from "@mantine/core";
 import Header from "@/components/shared/Header";
 import Footer from "@/components/shared/Footer";
-import DisclaimerModal from "@/components/shared/DisclaimerModal";
 import StatusBadge, { type AppStatus } from "@/components/shared/StatusBadge";
-import {
-  loadDisclaimerAccepted,
-  saveDisclaimerAccepted,
-} from "@/utils/storage";
-import { useState } from "react";
 
 type Tool = {
   emoji: string;
@@ -105,24 +99,11 @@ function ToolCard({ tool }: { tool: Tool }) {
 }
 
 export default function HomePage() {
-  const [disclaimerOpen, setDisclaimerOpen] = useState(
-    () => !loadDisclaimerAccepted(),
-  );
-
-  function acceptDisclaimer() {
-    saveDisclaimerAccepted();
-    setDisclaimerOpen(false);
-  }
-
   return (
     <>
       <Header title="Personal Finance" />
       <main>
         <Container size="xl" py="xl">
-          <DisclaimerModal
-            opened={disclaimerOpen}
-            onAccept={acceptDisclaimer}
-          />
           <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="lg">
             {TOOLS.map((tool) => (
               <ToolCard key={tool.title} tool={tool} />

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,6 +6,7 @@ import {
   localStorageColorSchemeManager,
 } from "@mantine/core";
 import type { ReactNode } from "react";
+import DisclaimerGate from "@/components/shared/DisclaimerGate";
 
 const theme = createTheme({
   primaryColor: "teal",
@@ -25,6 +26,7 @@ export default function Providers({ children }: { children: ReactNode }) {
       colorSchemeManager={colorSchemeManager}
     >
       {children}
+      <DisclaimerGate />
     </MantineProvider>
   );
 }

--- a/src/components/shared/DisclaimerGate.tsx
+++ b/src/components/shared/DisclaimerGate.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import DisclaimerModal from "./DisclaimerModal";
+import {
+  loadDisclaimerAccepted,
+  saveDisclaimerAccepted,
+} from "@/utils/storage";
+
+// Minimal store over the "disclaimer accepted" flag so the gate can read
+// localStorage without a hydration mismatch (and without a setState-in-effect).
+const listeners = new Set<() => void>();
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/**
+ * Mounts the first-visit disclaimer modal globally (via the root Providers) so
+ * it shows on direct entry to any route — not just the hub.
+ *
+ * The server snapshot reports "accepted" so the prerendered markup never
+ * contains the modal; after hydration the real localStorage value is read, and
+ * the modal opens only for visitors who haven't accepted yet.
+ */
+export default function DisclaimerGate() {
+  const accepted = useSyncExternalStore(
+    subscribe,
+    () => loadDisclaimerAccepted(),
+    () => true,
+  );
+
+  function acceptDisclaimer() {
+    saveDisclaimerAccepted();
+    listeners.forEach((listener) => listener());
+  }
+
+  return <DisclaimerModal opened={!accepted} onAccept={acceptDisclaimer} />;
+}

--- a/src/components/shared/DisclaimerModal.tsx
+++ b/src/components/shared/DisclaimerModal.tsx
@@ -35,8 +35,14 @@ const DisclaimerModal = ({ opened, onAccept }: DisclaimerModalProps) => {
               Before you start
             </Modal.Title>
             <Text size="sm">
-              Not financial advice. Results are estimates from your assumptions,
-              not predictions. Canada-specific and provided as-is.
+              Hi! This is a hobby project from a personal finance and FIRE
+              enthusiast — a small collection of free, Canada-focused
+              calculators built to make these numbers easier to explore.
+            </Text>
+            <Text size="sm">
+              It&apos;s not financial advice. Results are estimates based on the
+              assumptions you enter, not predictions, and provided as-is. For
+              big decisions, do your own research or talk to a professional.
             </Text>
             <Group justify="flex-end" mt="xs">
               <Button variant="default" onClick={handleLeave}>


### PR DESCRIPTION
## What

- **Bug fix**: the first-visit disclaimer modal only mounted on the hub, so entering directly at a tool route (e.g. `/rent-vs-buy`, `/retirement`, `/glide-path`) skipped it entirely. It now mounts globally via a `DisclaimerGate` in the root `Providers`, so it shows on first visit to **any** route. The duplicate per-page mount is removed from the hub.
- **Copy**: expanded the modal into a warmer, fuller note — framed as a hobby project from a personal finance / FIRE enthusiast — while keeping the "not financial advice / estimates / provided as-is" disclaimer.

## Notes

- `DisclaimerGate` reads the accepted flag via `useSyncExternalStore` (server snapshot reports "accepted") so the prerendered markup never contains the modal — no hydration mismatch, no `setState`-in-effect.
- e2e: a `beforeEach` pre-accepts the disclaimer so the now-global overlay doesn't sit over the app during the existing flows.

## Verified

lint · typecheck · 102 unit tests · 3 e2e — all pass. Manually confirmed the modal shows on direct `/rent-vs-buy` entry, dismisses on accept, and stays gone across navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)