### PR TITLE
Clarify glide-path γ/β input descriptions and retirement returns note

### DIFF
--- a/src/components/glide-path/InputForm.test.tsx
+++ b/src/components/glide-path/InputForm.test.tsx
@@ -27,13 +27,17 @@ describe("glide-path InputForm guidance", () => {
     renderForm();
 
     expect(
-      screen.getByText(/how much retirement spending responds to markets/i),
+      screen.getByText(/How well you tolerate market volatility/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/percentage of the current portfolio drawn each year/i),
+      screen.getByText(
+        /The percentage of the current portfolio drawn each year/i,
+      ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/how much to prioritize earlier retirement spending/i),
+      screen.getByText(
+        /How much the optimizer discounts later retirement years./i,
+      ),
     ).toBeInTheDocument();
   });
 

--- a/src/components/glide-path/InputForm.tsx
+++ b/src/components/glide-path/InputForm.tsx
@@ -141,7 +141,7 @@ export default function InputForm({
               <Stack gap={4}>
                 <FieldHeader
                   label="Spending flexibility"
-                  description="How much retirement spending responds to markets. 0 = fixed real dollars; 1 = fully follows the portfolio."
+                  description="How much retirement spending responds to markets. 0 = fixed real dollars (spend the same after a crash); 1 = fully follows the portfolio (a 20% drop cuts that year's withdrawal ~20%). 0.5 sits halfway."
                 />
                 <Box w="85%" mx="auto" pt="xs" pb="md">
                   <Slider

--- a/src/components/glide-path/InputForm.tsx
+++ b/src/components/glide-path/InputForm.tsx
@@ -174,7 +174,7 @@ export default function InputForm({
               <Stack gap={4}>
                 <FieldHeader
                   label="Risk aversion (γ)"
-                  description="Your tolerance for swings in retirement spending. 1 = aggressive; 3 = moderate; 8 = very cautious."
+                  description="How well you tolerate market volatility — pick the investor that sounds like you. 1 = very aggressive, 3 = balanced, 5 = conservative, 8 = very cautious."
                 />
                 <Group gap="xs" mt="xs" role="group" aria-label="Risk aversion">
                   {GAMMA_PRESETS.map((g) => (
@@ -217,7 +217,7 @@ export default function InputForm({
               <UserInputFormItem
                 {...num("beta")}
                 label="Time preference (β)"
-                description="How much to prioritize earlier retirement spending. 1.00 = even; lower values favor earlier years."
+                description="How much the optimizer discounts later retirement years. Pick the planner that sounds like you: 1.0 = very patient (every year counts equally), 0.98 = balanced, 0.95 = present-biased."
                 step={0.005}
               />
             </Stack>

--- a/src/components/retirement/InputForm.tsx
+++ b/src/components/retirement/InputForm.tsx
@@ -336,7 +336,7 @@ export default function InputForm({
                       <Stack gap="sm">
                         <Text size="xs" c="dimmed">
                           Custom returns are easy to overstate. The presets use
-                          long-run historical stock/bond data; higher figures
+                          long-term capital market assumptions; higher figures
                           make any plan look feasible. Use nominal
                           (pre-inflation) returns.
                         </Text>


### PR DESCRIPTION
## Summary
Reframes the Lifetime Allocation Optimizer's **risk aversion (γ)** and **time preference (β)** helper text around recognizable investor/planner types so users can self-select a reasonable value, and updates the retirement custom-returns note.

- **γ** — now maps the preset values to investor types (1 = very aggressive → 8 = very cautious) framed around tolerance for market volatility.
- **β** — clarifies it tunes the optimizer's weighting of near vs. distant retirement years (*not* the constant-dollar spending plan), with patient → present-biased planner anchors. This fixes a misread where the old "favor earlier spending" copy implied front-loaded spending, which doesn't happen at the default `flexibility = 0`.
- **Retirement** — custom-returns note now references "long-term capital market assumptions".

Copy-only changes; no logic touched. Lint and format check pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)