### PR TITLE
Improve allocator UX: declutter result, surface assumptions

### DIFF
--- a/src/components/allocator/AllocationSplit.tsx
+++ b/src/components/allocator/AllocationSplit.tsx
@@ -94,10 +94,12 @@ export default function AllocationSplit({
         </Stack>
         {registeredRoomFull && (
           <Text size="sm" c="orange.8" fw={600}>
-            Registered room full — remainder in non-registered.
+            {registeredRoom <= 0.01
+              ? "No registered room — the full amount goes to non-registered."
+              : "Registered room full — remainder in non-registered."}
           </Text>
         )}
-        <Alert variant="light" title="Do now">
+        <Alert variant="light" title="Do now (today's dollars)">
           <List size="sm" spacing={4}>
             {allocation.tfsa > 0 && (
               <List.Item>
@@ -125,7 +127,11 @@ export default function AllocationSplit({
         </Alert>
         {(allocation.rrspCarryForward.length > 0 ||
           allocation.refundTotal > 0) && (
-          <Alert variant="light" color="orange" title="Do later">
+          <Alert
+            variant="light"
+            color="orange"
+            title="Do later (future dollars)"
+          >
             <List size="sm" spacing={4}>
               {allocation.rrspCarryForward.map((claim) => (
                 <List.Item key={claim.age}>
@@ -154,30 +160,30 @@ export default function AllocationSplit({
             now.
           </Text>
         )}
-        {allocation.rrspDeductNow > 0 && (
-          <Alert
-            variant="light"
-            color="blue"
-            title="Why claim this amount now?"
-          >
-            <Text size="sm">
-              The current RRSP claim reduces modeled base taxable income from{" "}
-              {formatCAD(input.currentIncome)} to{" "}
-              {formatCAD(incomeAfterCurrentClaim)}. Its estimated current tax
-              refund is {formatCAD(estimatedCurrentRefund)}, an effective{" "}
-              {(effectiveCurrentRefundRate * 100).toFixed(1)}% refund rate
-              before investment distributions and unmodeled credits.
-            </Text>
-          </Alert>
-        )}
         <Divider />
-        <Alert variant="light" color="gray" title="Retirement valuation rates">
-          <Text size="sm">
-            RRSP balance haircut: {(rrspWithdrawalRate * 100).toFixed(1)}%.
-            Taxable capital gains: {input.capitalGainsTaxRatePct.toFixed(1)}%
-            after the 50% inclusion rate.
-          </Text>
-        </Alert>
+        <details>
+          <summary style={{ cursor: "pointer", fontWeight: 600, fontSize: 14 }}>
+            Show calculation detail
+          </summary>
+          <Stack gap="sm" mt="sm">
+            {allocation.rrspDeductNow > 0 && (
+              <Text size="sm">
+                The current RRSP claim reduces modeled base taxable income from{" "}
+                {formatCAD(input.currentIncome)} to{" "}
+                {formatCAD(incomeAfterCurrentClaim)}. Its estimated current tax
+                refund is {formatCAD(estimatedCurrentRefund)}, an effective{" "}
+                {(effectiveCurrentRefundRate * 100).toFixed(1)}% refund rate
+                before investment distributions and unmodeled credits.
+              </Text>
+            )}
+            <Text size="sm">
+              Retirement valuation rates — RRSP balance haircut:{" "}
+              {(rrspWithdrawalRate * 100).toFixed(1)}%. Taxable capital gains:{" "}
+              {input.capitalGainsTaxRatePct.toFixed(1)}% after the 50% inclusion
+              rate.
+            </Text>
+          </Stack>
+        </details>
         <Group justify="space-between" align="baseline">
           <Text size="sm" fw={600}>
             Projected after-tax at retirement

--- a/src/components/allocator/IncomeCurve.tsx
+++ b/src/components/allocator/IncomeCurve.tsx
@@ -178,12 +178,38 @@ export default function IncomeCurve({
           </ResponsiveContainer>
         </div>
         <Group gap="lg" wrap="wrap">
+          <Group gap={6} wrap="nowrap">
+            <span
+              style={{
+                width: 14,
+                height: 3,
+                borderRadius: 2,
+                background: TEAL,
+                display: "inline-block",
+              }}
+            />
+            <Text size="xs" c="dimmed">
+              Base income
+            </Text>
+          </Group>
+          <Group gap={6} wrap="nowrap">
+            <span
+              style={{
+                width: 10,
+                height: 10,
+                borderRadius: "50%",
+                background: ORANGE,
+                border: "1px solid white",
+                display: "inline-block",
+              }}
+            />
+            <Text size="xs" c="dimmed">
+              RRSP deduction claim
+            </Text>
+          </Group>
           <Text size="xs" c="dimmed">
             Income axis in today&apos;s dollars; claims are fixed nominal
-            dollars.
-          </Text>
-          <Text size="xs" c="dimmed">
-            Vertical line marks retirement.
+            dollars. Vertical line marks retirement.
           </Text>
         </Group>
         {claims.length > 0 && (

--- a/src/components/allocator/InputForm.tsx
+++ b/src/components/allocator/InputForm.tsx
@@ -61,10 +61,9 @@ export default function InputForm({ input, errors, onChange, onReset }: Props) {
 
   return (
     <>
-      <FormResetButton onReset={onReset} />
       <Accordion
         multiple
-        defaultValue={["you", "amount", "room"]}
+        defaultValue={["you", "amount", "room", "returns", "retirement"]}
         variant="contained"
       >
         <Accordion.Item value="you">
@@ -84,6 +83,7 @@ export default function InputForm({ input, errors, onChange, onReset }: Props) {
                 />
                 <Select
                   label="Province"
+                  description="Only NB, ON, and BC tax rules are modeled"
                   data={PROVINCES}
                   value={input.province}
                   onChange={(value) => value && onChange("province", value)}
@@ -113,6 +113,13 @@ export default function InputForm({ input, errors, onChange, onReset }: Props) {
                 <UserInputFormItem
                   {...num("salaryGrowthPct")}
                   label="Real salary growth"
+                  description={
+                    input.salaryCurve === "aggressive"
+                      ? "Fast climb applies 1.5x this rate for 20 years, then plateaus."
+                      : input.salaryCurve === "early-peak"
+                        ? "Early peak applies this rate for 15 years, then plateaus."
+                        : "Compounds at this rate every year until retirement."
+                  }
                   suffix="%"
                 />
               )}
@@ -172,6 +179,7 @@ export default function InputForm({ input, errors, onChange, onReset }: Props) {
                 <UserInputFormItem
                   {...num("portfolioReturn")}
                   label="Nominal return"
+                  description="Editing this switches Portfolio to Custom return."
                   suffix="%"
                   onChange={(value) => {
                     onChange("portfolioPresetId", "custom");
@@ -235,6 +243,7 @@ export default function InputForm({ input, errors, onChange, onReset }: Props) {
           </Accordion.Panel>
         </Accordion.Item>
       </Accordion>
+      <FormResetButton onReset={onReset} confirm mt="lg" mb={0} />
     </>
   );
 }

--- a/src/components/allocator/Result.tsx
+++ b/src/components/allocator/Result.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Alert, Loader, Stack, Text } from "@mantine/core";
+import { Alert, Anchor, Loader, Stack, Text } from "@mantine/core";
 import { IconAlertCircle, IconInfoCircle } from "@tabler/icons-react";
 import AllocationSplit from "./AllocationSplit";
 import IncomeCurve from "./IncomeCurve";
@@ -45,19 +45,14 @@ export default function Result({
     <Stack gap="lg">
       <AllocationSplit allocation={allocation} input={input} />
       <IncomeCurve allocation={allocation} input={input} />
-      <Alert variant="light" color="gray" title="Model scope">
-        <Text size="sm">
-          Deterministic illustration. Result amounts (projected value, refunds,
-          and the carry-forward benefit) are shown in nominal (future) dollars;
-          the income-curve chart below is in real (today&apos;s) dollars to keep
-          its shape readable. The 2026 tax brackets and thresholds are modeled
-          as fully indexed to inflation, so they keep their real value over
-          time. Registered room is static and carried deductions stay fixed
-          nominal amounts. Returns are constant. Deduction claims are optimized
-          only through the year before retirement. Verify room and tax advice
-          before acting.
-        </Text>
-      </Alert>
+      <Text size="xs" c="dimmed">
+        Deterministic illustration — returns and tax rules are held constant.
+        Verify room and tax advice before acting.{" "}
+        <Anchor href="#model-assumptions" size="xs">
+          See full model assumptions
+        </Anchor>
+        .
+      </Text>
     </Stack>
   );
 }

--- a/src/components/allocator/TaxAssumptions.tsx
+++ b/src/components/allocator/TaxAssumptions.tsx
@@ -2,7 +2,7 @@ import { Container, Paper, Stack, Text } from "@mantine/core";
 
 export default function TaxAssumptions() {
   return (
-    <Container size="xl" pt="xl" pb="xs">
+    <Container size="xl" pt="xl" pb="xs" id="model-assumptions">
       <Paper withBorder p="md" radius="md">
         <details>
           <summary style={{ cursor: "pointer", fontWeight: 600 }}>

--- a/src/components/shared/FormResetButton.tsx
+++ b/src/components/shared/FormResetButton.tsx
@@ -1,16 +1,36 @@
 import { Button } from "@mantine/core";
 import { IconRotate } from "@tabler/icons-react";
 
-export default function FormResetButton({ onReset }: { onReset: () => void }) {
+export default function FormResetButton({
+  onReset,
+  confirm = false,
+  mt = "md",
+  mb = "6",
+}: {
+  onReset: () => void;
+  /** Ask for confirmation before resetting (guards against accidental wipes). */
+  confirm?: boolean;
+  mt?: string | number;
+  mb?: string | number;
+}) {
+  const handleClick = () => {
+    if (
+      confirm &&
+      !window.confirm("Reset all inputs to their default values?")
+    ) {
+      return;
+    }
+    onReset();
+  };
   return (
     <Button
       variant="transparent"
       color="red"
       leftSection={<IconRotate size={14} />}
-      onClick={onReset}
+      onClick={handleClick}
       size="xs"
-      mt="md"
-      mb="6"
+      mt={mt}
+      mb={mb}
     >
       Reset to defaults
     </Button>


### PR DESCRIPTION
Addresses a UX/UI review of the **allocator** tool. No logic/finance-engine changes — UI, copy, and disclosure only.

## Changes
- **Declutter result:** "Why claim now" + retirement-rate Alerts collapse into one "Show calculation detail" disclosure.
- **Single source for assumptions:** drop the duplicated "Model scope" Alert; link to the anchored full assumptions section.
- **Unit clarity:** "Do now (today's dollars)" / "Do later (future dollars)"; clearer zero-registered-room message.
- **Stop hiding assumptions:** all input accordions open by default (Returns/Retirement were closed but drive the result).
- **Input hints:** salary-growth field describes the selected curve's effect; nominal-return field warns it switches Portfolio to Custom; province coverage note.
- **Chart legend** for income line vs claim dots.
- **Reset button** moved to form bottom with an opt-in confirm dialog. `FormResetButton` stays backward-compatible (other tools unchanged).

## Verification
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format` ✅
- allocator unit + component tests: 51 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)