### PR TITLE
Glide-path: TIPS-ETF evidence, regime-robustness framing, bond-menu restructure (§2g)

### DIFF
--- a/analysis/glide_path/research_history.py
+++ b/analysis/glide_path/research_history.py
@@ -399,11 +399,153 @@ def run_variance_ratios(args):
               f"{bill_vol:>6.1f}%  {history.observations:>5}")
 
 
+def run_bills_block(args):
+    """Forward-block with a real **bills** leg carrying its OWN historical persistence.
+
+    Unlike the menu cells (which force the safe asset iid, VR=1), this replaces the long-bond leg
+    with JST's empirical real short-bill series — rescaled to the given bills marginals (default
+    0.75% real / 2% vol) — and block-bootstraps it jointly with equity. So the bills leg keeps its
+    real-world VR(10y)≈2.4 inflation persistence: the honest "real-world GIC/bill ladder" answer,
+    vs the menu's idealized VR=1 short asset.
+    """
+    from unittest.mock import patch
+
+    from analysis.glide_path import recommender as R
+    from analysis.shared import jst_history as J
+
+    eq_m, eq_v, _, _ = R._forward_anchors(R.PWL_CURVE, 2.1, True)
+    bill_m, bill_v = args.bills_mean / 100.0, args.bills_vol / 100.0
+
+    # Joint per-country equity+bills panel: inner-join on year so both legs are present and paired,
+    # with shared per-country segment ids (no block bridges countries/gaps).
+    frame = J.load_jst_frame()
+    eq_parts, bill_parts, seg_country, seg_years = [], [], [], []
+    for country in frame["country"].dropna().unique():
+        sub = frame[frame["country"] == country]
+        eq = J.real_stock_fixed_income_returns(sub)[["year", "equity"]]
+        bl = J.real_bill_returns(sub)  # ["year", "bills"]
+        merged = eq.merge(bl, on="year", how="inner").sort_values("year")
+        if merged.empty:
+            continue
+        eq_parts.append(merged["equity"].to_numpy(dtype=float))
+        bill_parts.append(merged["bills"].to_numpy(dtype=float))
+        seg_country.append(np.full(len(merged), country))
+        seg_years.append(merged["year"].to_numpy(dtype=int))
+    equity = np.concatenate(eq_parts)
+    bills = np.concatenate(bill_parts)
+    years = np.concatenate(seg_years)
+    segment_ids = J._assign_segments(np.concatenate(seg_country), years)
+
+    joint = J.rescale_to_targets(
+        J.ReturnHistory(years=years, equity=equity, fixed_income=bills,
+                        label="equity+bills joint", country_count=len(eq_parts),
+                        segment_ids=segment_ids),
+        equity_mean=eq_m, equity_vol=eq_v, fixed_income_mean=bill_m, fixed_income_vol=bill_v,
+        label_suffix="forward-CMA rescaled (bills)")
+
+    print("\n" + "=" * 100)
+    print("FORWARD-BLOCK with a REAL BILLS leg (bills keep their own historical persistence)")
+    print(f"  bills marginals: {args.bills_mean:.2f}% real / {args.bills_vol:.2f}% vol; "
+          f"equity keeps full forward-block sequencing. Compare to menu cell (a) nominal bonds.")
+    print(f"  bills VR(10y) = {J.variance_ratio(joint.fixed_income, 10, joint.segment_ids):.2f} "
+          f"(iid null = 1.0; >1 = persistent inflation bleed)")
+    print("=" * 100)
+    with patch.object(R, "_load_history", return_value=joint):
+        rec = recommend_glide_path(**base_kwargs(args, return_mode="forward-block",
+                                                 dataset="pooled", block_years=args.block_years))
+    print(summary_row("bills (forward-block, own persistence)", rec))
+
+    rng = np.random.default_rng(11)
+    iid_bills = bill_m + bill_v * rng.standard_normal(joint.observations)
+    iid_hist = J.ReturnHistory(years=joint.years, equity=joint.equity, fixed_income=iid_bills,
+                               label="bills-iid", country_count=joint.country_count,
+                               segment_ids=joint.segment_ids)
+
+    def split_sample(history, n_years, n_paths, *, mode, block_years, seed):
+        blk = J.sample_indices(history.observations, n_years, n_paths, mode="historical-block",
+                               block_years=block_years, seed=seed, segment_ids=history.segment_ids)
+        iid = J.sample_indices(history.observations, n_years, n_paths, mode="historical-iid",
+                               block_years=block_years, seed=seed + 1)
+        return history.equity[blk], history.fixed_income[iid]
+
+    with patch.object(R, "_load_history", return_value=iid_hist), \
+         patch.object(J, "sample_return_paths", split_sample):
+        rec_iid = recommend_glide_path(**base_kwargs(args, return_mode="historical-block",
+                                                     dataset="pooled", block_years=args.block_years))
+    print(summary_row("bills (iid, VR=1 — for contrast)", rec_iid))
+
+
+def run_tips_etf(args):
+    """Data-anchored realistic short-TIPS-ETF leg (e.g. XSTH/VTIP), not the idealized VR=1 cell.
+
+    Menu cell (e) assumes the buyable real asset is VR=1. Live ETF data (VTIP/STIP 2012-, deflated
+    by US CPI) says short-TIPS real returns are only *mildly* persistent — annual AR(1) phi ~= 0.13,
+    i.e. VR(2y) ~= 1.13 — because the inflation-accretion leg (VR~=1) dominates but the real-yield
+    repricing leg adds a little persistence and ~0.6 correlation to short Treasuries. Still far below
+    short *nominal* bills (VR(2y) ~= 4.8 in the same data; ~2.9 in JST). This builds the safe leg as
+    an AR(1) at VTIP's measured phi/marginals (--tips-mean/--tips-vol/--tips-phi), block-sampled
+    jointly so it carries that mild persistence while equity keeps its JST forward-block sequencing.
+    """
+    from unittest.mock import patch
+
+    from analysis.glide_path import recommender as R
+    from analysis.shared import jst_history as J
+
+    eq_m, eq_v, _, _ = R._forward_anchors(R.PWL_CURVE, 2.1, True)
+    tips_m, tips_v, phi = args.tips_mean / 100.0, args.tips_vol / 100.0, args.tips_phi
+
+    hist = J.load_pooled_country_returns()
+    n = hist.observations
+    seg = hist.segment_ids if hist.segment_ids is not None else np.zeros(n, dtype=int)
+
+    def ar1(seed):
+        """AR(1) with the given phi at (tips_m, tips_v) marginals; restart each segment."""
+        rng = np.random.default_rng(seed)
+        innov_sd = tips_v * np.sqrt(1 - phi * phi)
+        out = np.empty(n)
+        prev, x = None, 0.0
+        for i in range(n):
+            if seg[i] != prev:
+                x = rng.standard_normal() * tips_v
+                prev = seg[i]
+            else:
+                x = phi * x + rng.standard_normal() * innov_sd
+            out[i] = tips_m + x
+        return out
+
+    def make_hist(series, label):
+        return J.ReturnHistory(years=hist.years, equity=hist.equity, fixed_income=series,
+                               label=label, country_count=hist.country_count,
+                               segment_ids=hist.segment_ids)
+
+    def split_sample(history, n_years, n_paths, *, mode, block_years, seed):
+        blk = J.sample_indices(history.observations, n_years, n_paths, mode="historical-block",
+                               block_years=block_years, seed=seed, segment_ids=history.segment_ids)
+        return history.equity[blk], history.fixed_income[blk]
+
+    print("\n" + "=" * 100)
+    print("REALISTIC short-TIPS-ETF leg (data-anchored AR(1), not idealized VR=1)")
+    print(f"  marginals {args.tips_mean:.2f}% real / {args.tips_vol:.2f}% vol, AR(1) phi={phi:.2f} "
+          f"(VTIP-measured); equity keeps JST forward-block sequencing.")
+    print("=" * 100)
+    for label, ph, seed in [(f"realistic XSTH (phi={phi:.2f}, VR(2y)~{1 + phi:.2f})", phi, 7),
+                            ("idealized VR=1 (phi=0, = cell e)", 0.0, 7)]:
+        series = ar1(seed) if ph == phi else (
+            tips_m + tips_v * np.random.default_rng(seed).standard_normal(n))
+        with patch.object(R, "_load_history", return_value=make_hist(series, label)), \
+             patch.object(J, "sample_return_paths", split_sample):
+            rec = recommend_glide_path(**base_kwargs(args, return_mode="historical-block",
+                                                     dataset="pooled", block_years=args.block_years))
+        print(summary_row(label, rec))
+
+
 SECTIONS = {
     "matrix": run_matrix,
     "blocks": run_block_sweep,
     "channels": run_channels,
     "menu": run_menu,
+    "bills-block": run_bills_block,
+    "tips-etf": run_tips_etf,
     "gamma": run_gamma_sweep,
     "curves": run_flat_curves,
     "vr": run_variance_ratios,
@@ -428,6 +570,16 @@ def main(argv=None):
     ap.add_argument("--gamma", type=float, default=4.0)
     ap.add_argument("--interval", type=int, default=5)
     ap.add_argument("--block-years", type=int, default=10)
+    ap.add_argument("--bills-mean", type=float, default=0.75,
+                    help="bills-block: real bill mean return %% (default 0.75)")
+    ap.add_argument("--bills-vol", type=float, default=2.0,
+                    help="bills-block: real bill vol %% (default 2.0)")
+    ap.add_argument("--tips-mean", type=float, default=1.42,
+                    help="tips-etf: real mean %% (default 1.42, = menu cell e/b)")
+    ap.add_argument("--tips-vol", type=float, default=5.4,
+                    help="tips-etf: real vol %% (default 5.4, = menu cell e/b)")
+    ap.add_argument("--tips-phi", type=float, default=0.13,
+                    help="tips-etf: annual AR(1) phi (default 0.13, VTIP-measured)")
     ap.add_argument("--paths", type=int, default=6_000)
     ap.add_argument("--passes", type=int, default=10)
     ap.add_argument("--quick", action="store_true",

--- a/docs/glide-path/methodology.md
+++ b/docs/glide-path/methodology.md
@@ -530,7 +530,35 @@ equity recovery). Note also that every cut's CE-vs-flat-weight curve is shallow:
 between 50% and 100%, but the welfare spread across that range stays ≤ ~2% of CE — the era choice
 moves the _allocation_ answer far more than the _welfare_ answer.
 
-**Robustness: the bond menu.** The channel factorial says the flip is driven by what history does
+---
+
+### 2g. The bond menu — is flat-100% about equity, or about the only bond being long-nominal?
+
+> **In one paragraph.** Flat-100% is a verdict on _long nominal bonds_, not on equity. Swap the
+> bond leg for a real, short-duration asset and the optimum drops from 100% to **~45% equity** —
+> the reachable figure, what a short-TIPS ETF (XSTH) delivers. A further drop to ~20% needs an
+> idealized hold-to-maturity _ladder_ no Canadian retail product offers, so read 20% as an upper
+> bound. The driver is **persistence, not amplitude**: nominal bonds' real returns compound bad
+> (inflation) decades (VR(10y)≈1.7), and only _inflation linkage_ — not short duration — removes
+> that. We confirm this three ways (hold mean/vol fixed, vary only persistence), check it against
+> live TIPS-ETF data, and map it to the buyable Canadian menu below. The whole result is
+> regime-conditional: it holds in persistent-inflation regimes and reverses in the 1990–2020
+> disinflation cut, which is why the real asset is best read as a _hedge across regimes_, not a
+> free lunch.
+>
+> **Practitioner takeaway** (not advice). Real, short-duration is the high-value add the two-asset
+> product can't express. In Canada: **XSTH** (short US TIPS, CAD-hedged) is the closest buyable
+> proxy — short duration, US-CPI basis risk; **XRB** (Canadian RRB ETF) matches Canadian CPI but is
+> long-duration; a **GIC/bill ladder** fixes drawdown but not inflation persistence. None is the
+> idealized short-domestic-real ladder (Canada stopped issuing RRBs in 2022). Without a real asset,
+> for the sequence-hedge role: GIC ladder > XSB > ZAG, all on the amplitude axis only.
+
+The rest of this section is the evidence behind that summary: (1) the menu experiment; (2) whether a
+real-world short asset is really VR=1 — the empirical bills check; (3) the persistence-vs-amplitude
+axes that result implies; (4) the live TIPS-ETF data confirming the buyable proxy; (5) the Canadian
+product menu; (6) regime conditionality.
+
+**(1) The menu experiment.** The channel factorial says the flip is driven by what history does
 to the _bond_ leg, which raises the question: is flat-100% about equity's merit, or about the only
 modeled alternative being long nominal bonds? Replacing the bond leg with a synthetic VR=1 real
 asset (iid, zero equity correlation — an idealized short-TIPS/RRB ladder) while equity keeps its
@@ -557,28 +585,15 @@ Canadian retail investor can buy the first but not the second. (Raising the ladd
 1.42% to 2.0% pushes the idealized optimum further still, to ~10% / $60.0k — the **return** axis — but
 that stacks an optimistic yield on top of the unreachable ladder vol, so it is not tabulated.)
 
-**What's actually buyable in Canada, mapped onto these cells.** There is no retail short-real
-_ladder_ product (Canada stopped issuing RRBs in 2022; existing RRBs are long-duration anyway). The
-two implementable real-asset routes are:
+So the menu verdict is **~45% equity, not 20%**: cell (b)/(d)'s 45% is the reachable figure (a real
+asset at full short-bond vol); cell (c)'s 20% needs the ladder's hold-to-maturity vol suppression,
+unreachable in retail — the ETF-vs-ladder gap, not RRB discontinuation, is the binding constraint
+(it applies wherever real bonds trade only as funds). The product's two-asset candidate set cannot
+express any of this; it is the most consequential menu limitation (§7). The buyable Canadian menu is
+mapped in step (4). Reproduce: `--sections menu` (cell (d) prints as the `XSTH ETF proxy` row; the
+2.0%-real sensitivity as `short-TIPS ladder @2% real`).
 
-- A **GIC / bill ladder** — an actual ladder (hold-to-maturity), but _nominal_: it fixes amplitude,
-  not persistence (the "short nominal" row of the amplitude-vs-persistence table below — VR still
-  bad). It does **not** move the optimum off the nominal-bond answer on the persistence axis.
-- A **short-term, CAD-hedged US-TIPS ETF** (e.g. XSTH / ZTIP.F) — real and short-duration, but a
-  perpetual marked-to-market _fund_, not a ladder: it carries short-bond price vol, not the ladder's
-  2%. This is cell (d): it delivers the persistence fix (→45%) but **not** the ladder's amplitude
-  suppression (so not 20%). Residual idealizations even at (d): it tracks _US_ CPI, not Canadian
-  (basis risk on the exact axis it's bought for), and the model pins its real yield at 1.42%.
-
-So the implementable verdict is **~45% equity, not 20%**: cell (c)'s 20% requires a hold-to-maturity
-real ladder that no Canadian retail wrapper provides, and the ETF-vs-ladder gap — not RRB
-discontinuation — is the binding constraint (it applies wherever real bonds trade only as funds).
-Read (c) as the idealized upper bound; read (d) as the reachable figure. The product's two-asset
-candidate set cannot express any of this; it is the most consequential menu limitation (§7).
-Reproduce: `--sections menu` on the same `research_history` command as above (doc cell (d) prints as
-the `XSTH ETF proxy` row; the 2.0%-real sensitivity as `short-TIPS ladder @2% real`).
-
-**Is the synthetic VR=1 leg realistic? The empirical short asset says short helps but is not
+**(2) Is the synthetic VR=1 leg realistic? The empirical short asset says short helps but is not
 enough.** Cells (b)–(d) assume the alternative asset is mean-reverting (VR=1 or a clean
 real ladder). That is a property of being _inflation-linked_, not of being _short_. JST carries
 an actual short asset — rolling short-term government **bills** (`bill_rate`, deflated by CPI) —
@@ -604,7 +619,7 @@ collapse the optimum the way cell (c) does. It takes short **and inflation-linke
 no nominal instrument has — to deliver the VR=1 leg, which is precisely why an idealized
 short-TIPS/RRB ladder, not a bill ladder, is the asset that flips the answer.
 
-**This is not "short duration is bad" — short fixes a different axis.** A safe asset can fail on
+**(3) This is not "short duration is bad" — short fixes a different axis.** A safe asset can fail on
 two independent dimensions, and VR measures only the second:
 
 - **Amplitude** — how _deep_ a bad spell goes (vol, drawdown size). Set by **duration**. A rate
@@ -632,6 +647,60 @@ that gives 1990–2020 bills VR(10y)=3.90) scores high without being a danger. T
 persistent _negative_ run — a hot-inflation decade like the 1970s — which is why the full-sample
 and post-1950 cuts (which contain it) are the ones that matter for sizing a real-asset slice.
 Reproduce: `--sections vr` on the same `research_history` command (now prints a `bills` row).
+
+**(4) Does a real-world TIPS _ETF_ actually deliver VR≈1? Live fund data says yes — mostly.** Cells
+(b)–(e) and the bills test treat the inflation-linked leg as clean VR=1. A TIPS _ETF_ is not a
+ladder: its real return = inflation accretion (VR≈1) **+** real-yield repricing (persistent, and
+never extinguished by maturity because the fund rolls perpetually). So the VR=1 assumption is, in
+principle, optimistic for the buyable instrument. We checked it against the actual funds — VTIP and
+STIP (US short-TIPS ETFs, XSTH's siblings), deflated by US CPI, 2012–2025 — alongside short
+Treasuries (SHY/VGSH) over the same window, which **includes the 2021–23 inflation shock**:
+
+| Real series (US, 2012–25)   | real μ/yr | VR(2y) |
+| --------------------------- | --------- | ------ |
+| VTIP (short TIPS ETF)       | −0.45%    | ~1.1   |
+| STIP (0–5y TIPS ETF)        | −0.51%    | ~1.6   |
+| SHY / VGSH (short Treasury) | −1.3%     | ~4.8   |
+
+Two readings. (1) The repricing leg _is_ real — short-TIPS and short-Treasury real returns
+correlate ~0.6 (shared real-rate factor), so the ETF is not an independent VR=1 asset. (2) But the
+accretion leg dominates: TIPS VR(2y)≈1.1–1.6 sits next to the iid null, **far** from short
+nominal's ~4.8, and TIPS earned **+~0.9pp/yr real** over short Treasuries _through_ the inflation
+shock. Putting VTIP's measured persistence (annual AR(1) φ≈0.13, i.e. VR(2y)≈1.13) through the
+optimizer at the menu marginals moves the tent only ~5pp of equity vs the idealized φ=0 — not the
+~55pp that separates VR=1 from the nominal corner. **The repricing objection is real but
+second-order: a short-TIPS ETF keeps most of the idealized real asset's tent benefit and does _not_
+collapse to short-Treasury behaviour.** (Caveat: φ≈0.13 is 13 annual observations — a wide CI; read
+"mildly persistent, not 4.8," not a precise point.) Reproduce: `--sections tips-etf`
+(`--tips-mean`/`--tips-vol`/`--tips-phi`).
+
+**(5) What a Canadian can actually buy — and the constraint that bites.** The real-asset slice is
+implementable in Canada, but not in its idealized form. The buyable menu, mapped onto the two axes:
+
+| Product (CAD investor)                        | amplitude (duration) | persistence (CPI link)  | residual                         |
+| --------------------------------------------- | -------------------- | ----------------------- | -------------------------------- |
+| **XSTH / ZTIP.F** (short US TIPS, CAD-hedged) | good (0–5y)          | good — but **US** CPI   | CPI basis vs CAD liability       |
+| **XRB** (Canadian RRB ETF)                    | **bad (~13–15y)**    | good — **Canadian** CPI | 2022-style drawdown (XRB ≈ −14%) |
+| GIC / bill ladder                             | good (HTM, no marks) | **none — nominal**      | persistence axis open            |
+
+The hard constraint: **no product offers short duration _and_ Canadian CPI.** Canada stopped issuing
+RRBs in 2022 and the outstanding ones are long-dated, so a short _domestic_ real ladder does not
+exist. XSTH buys amplitude at the cost of US-CPI basis risk; XRB buys CPI-match at the cost of
+long-duration amplitude (and partial rate-bull/deflation-hedge behaviour like long nominal bonds).
+For the sequence-hedge role this section is about, **XSTH is the better fit** (amplitude is the
+cleaner risk to cut, and CAD/US CPI correlate ~0.7–0.8); XRB is the better _pure_ Canadian-CPI hedge
+for a high-drawdown-tolerance holder; a blend approximates the unavailable short-domestic-real asset.
+
+**(6) Regime-robustness — why this is a hedge, not a free lunch.** The menu result is itself
+regime-conditional, and the same monetary-regime judgment that governs flat-100% governs the value
+of TIPS. In the **persistent-inflation** regime (full sample, post-1950, the 1970s) nominal bonds
+bleed (VR>1) and TIPS earns its keep. In the **disinflation + duration-bull** regime (1990–2020,
+bond VR(10y)=0.50) nominal bonds already mean-revert and recover, the interior tent returns, and
+TIPS is largely _redundant_. So the case for the real asset is not "it beats bonds" but "it is the
+one safe asset adequate in **both** regimes" — it dominates the regime _bet_ a nominal holder is
+otherwise forced to make. (The 1990–2020 mean reversion is substantially the one-off duration bull —
+rates 8%→0%, unrepeatable from today — and bills stayed VR>1 even then; see the era table in §2f and
+the caveats in §4.)
 
 ---
 


### PR DESCRIPTION
## Summary

Extends the bond-menu finding with the evidence gathered this session and reorganizes it into a navigable subsection. Doc + research harness only — no app/runtime changes.

### Research harness (`research_history.py`)
Two new sections turn earlier *inferences* into *measured* results:
- **`bills-block`** — forward-block with a real bills leg carrying its **own** historical persistence (VR(10y)=2.86) → **flat-100%**; same marginals iid (VR=1) → **45%**. Direct proof that persistence, not amplitude, drives the tent: low vol (2% vs 5.4%) can't substitute for inflation linkage.
- **`tips-etf`** — data-anchored AR(1) leg at VTIP's measured φ=0.13 (VR(2y)≈1.13). Idealized VR=1 → ~30% equity; realistic ETF persistence → ~35%. The repricing-persistence objection costs ~5pp, not the ~55pp to the nominal corner.

### Methodology doc — new §2g (restructure + nav + split)
- One-paragraph **summary box** + split-out **practitioner takeaway** (XSTH / XRB / GIC mapping), then six labeled evidence steps.
- **Live TIPS-ETF data**: VTIP/STIP real VR(2y)≈1.1 vs short Treasury ≈4.8, and +0.9pp/yr real *through* the 2021-23 inflation shock — confirms cell (e)'s VR=1 assumption is robust to the ETF-vs-ladder objection.
- **Canadian product reality**: no short-domestic-real product exists (RRBs discontinued 2022); the short-duration-vs-Canadian-CPI tradeoff (XSTH vs XRB) is the binding constraint.
- **Regime-robustness**: the real asset is a hedge across regimes (persistent-inflation vs the 1990-2020 disinflation cut where nominal bonds already mean-revert), not a free lunch.
- De-duplicated the Canada mapping; root cause restated as joint persistence (bonds) × mean-reversion (equity).

## Testing
- `python3 -m unittest discover -s analysis` — 44 pass ✓
- Both new sections reproduce the doc's figures (bills 100%/45% VR=2.86; tips ~30/35%) ✓
- `lint` / `typecheck` / `format:check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)