### PR TITLE
Add multi-broker ACB imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ yarn-error.log*
 # JST Macrohistory data cache (downloaded, not committed)
 analysis/.data/
 analysis/artifacts/
+
+# local files
+.local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ codex exec -m <model> -c model_reasoning_effort=<level> -s workspace-write -C <r
 
 **Always review Codex diff.** Watch for: out-of-scope edits, logic changes in "mechanical" passes, glossed regressions.
 
+Before pushing a branch, run `npm run format:check` in addition to the task-relevant tests/checks.
+
 ## CI/CD
 
 - `ci.yml`: lint + typecheck + format + tests + build + Playwright on every PR and `main` push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,12 @@ Types: **TypeScript** `.ts`/`.tsx`. Shared domain types: `src/types.ts`.
 
 **Roles:** Claude plans/reviews (conceptual risk: direction, UX, finance modeling, architecture). Codex executes/verifies (concrete risk: edits, refactors, tests, lint/build/checks). One writer at a time.
 
+**Default split:** Codex handles scoped implementation directly. Use Claude planning when the task changes finance semantics, adds a tool/route, reshapes UX workflows, or crosses architecture boundaries. If the task is a narrow UI/copy/test fix, keep it with Codex unless Claude is already editing the same files.
+
+**Scope discipline:** Match the user's requested surface. For narrow copy/UI/mechanical tasks, do not refactor adjacent code, update unrelated docs, or "fix" nearby stale tests unless needed to complete the request. Report unrelated failures separately.
+
+**Worktree safety:** Start with `git status --short` before edits. Never revert or overwrite unrelated user changes. If touched files already contain user edits, work with them and keep the patch minimal.
+
 ### Task tiers
 
 | Tier | Examples | Who plans | Who executes | Who reviews |
@@ -42,7 +48,7 @@ scripts/codex-run.sh standard "<task>"   # gpt-5.4,      medium
 scripts/codex-run.sh complex  "<task>"   # gpt-5.5,      high
 ```
 
-`auto` promotes finance/modeling, methodology, architecture, migration, and security work to `complex`; chooses `trivial` only for clearly mechanical tasks; and defaults uncertain work to `standard`. Preview routing without launching Codex using `scripts/codex-run.sh --dry-run auto "<task>"`.
+`auto` promotes finance/modeling, methodology, architecture, migration, and security work to `complex`; chooses `trivial` only for clearly mechanical tasks; and defaults uncertain work to `standard`. Prefer `trivial` for unambiguous small changes; promote when user-visible workflow, modeling semantics, architecture, or data migration risk is unclear. Preview routing without launching Codex using `scripts/codex-run.sh --dry-run auto "<task>"`.
 
 Use `$route-codex-task` when classification needs judgment or file inspection. The repo-scoped skill recommends a tier and verification scope; the wrapper performs the actual model and effort selection.
 
@@ -54,7 +60,14 @@ codex exec -m <model> -c model_reasoning_effort=<level> -s workspace-write -C <r
 
 **Always review Codex diff.** Watch for: out-of-scope edits, logic changes in "mechanical" passes, glossed regressions.
 
-Before pushing a branch, run `npm run format:check` in addition to the task-relevant tests/checks.
+## Definition of Done
+
+- Run the narrowest relevant verification first: `npm run lint`, `npm run typecheck`, `npm test`, Python unittest, or targeted suites.
+- Run `npm run format:check` before pushing or handing off a branch.
+- For visible UI or interaction changes, run the dev server and verify in browser when feasible. If browser verification is blocked, say so explicitly.
+- For build/export behavior, run `npm run build`.
+- For e2e-sensitive flows, run `npm run test:e2e` or the relevant Playwright spec.
+- Summarize changed files, verification run, and any known unrelated failures.
 
 ## CI/CD
 

--- a/src/components/acb/AGENTS.md
+++ b/src/components/acb/AGENTS.md
@@ -1,19 +1,27 @@
 # ACB Tool
 
-Upload Wealthsimple CSV → compute adjusted cost basis for non-registered holdings.
+Upload Wealthsimple CSV, Questrade XLSX, or IBKR CSV → compute adjusted cost basis for non-registered holdings.
+
+Results are scoped to one brokerage at a time (auto-detected from each file; a `SegmentedControl` switches between brokers when more than one is uploaded). State is in-memory only — not persisted.
 
 ## Files
 
-- `Main.tsx` — state container, persists to localStorage via `src/utils/storage.ts`
+- `Main.tsx` — state container; broker scoping (`activeBroker`/`effectiveBroker`), per-account registration overrides (`accountOverrides`)
 - `AcbApp.tsx` — `"use client"` wrapper, lazy-loads Main (`ssr:false`)
-- `FileUpload.tsx` — CSV drag-drop input
+- `FileUpload.tsx` — CSV/XLSX drag-drop input
 - `FilePreviewModal.tsx` — preview parsed rows before processing
 - `HoldingsTable.tsx` — per-symbol ACB table with lot tracking
 - `YearlyACBTable.tsx` — year-by-year ACB breakdown
 - `AccountView.tsx` — account-level summary
+- `AccountTypeMarker.tsx` — registered/non-registered toggle for IBKR consolidated sub-accounts whose type can't be detected
 - `SummaryBar.tsx` — top-level summary stats
 - `T3Modal.tsx` — T3 slip input for return-of-capital adjustments
 
 ## Engine
 
-`src/utils/acb/parser.ts` — parses Wealthsimple activity export CSV → ACB calculation logic
+- `src/utils/acb/parser.ts` — dispatches Wealthsimple CSV / Questrade rows / IBKR CSV → ACB calculation logic. Each tx carries a `broker` tag. `resolveRegistered()` decides registration: user override (by `accountId`) wins, else regex on `accountType`.
+- `src/utils/acb/xlsx.ts` — zero-dep XLSX reader using `DecompressionStream` and a small ZIP parser
+
+## IBKR account types
+
+A consolidated IBKR statement (`Custom Consolidated` / multiple `Accounts Included`) spans sub-accounts with different registration, and its header only describes the _primary_ account — so each trade's `accountType` is left empty and the user marks each sub-account via `AccountTypeMarker`. A single-account IBKR export auto-classifies from its `Customer Type`.

--- a/src/components/acb/AccountTypeMarker.test.tsx
+++ b/src/components/acb/AccountTypeMarker.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { renderWithMantine, screen } from "@/test-utils";
+import AccountTypeMarker from "./AccountTypeMarker";
+
+describe("AccountTypeMarker", () => {
+  it("renders an editable control for an unknown account type", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    renderWithMantine(
+      <AccountTypeMarker
+        accounts={[{ accountId: "U123", accountType: "", detectedRegistered: false }]}
+        overrides={{}}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByText("Registered"));
+
+    expect(onChange).toHaveBeenCalledWith("U123", "registered");
+  });
+
+  it("renders known account types read-only", () => {
+    renderWithMantine(
+      <AccountTypeMarker
+        accounts={[{ accountId: "RSP1", accountType: "RRSP", detectedRegistered: true }]}
+        overrides={{}}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("RSP1")).toBeInTheDocument();
+    expect(screen.getByText("Registered (detected)")).toBeInTheDocument();
+    expect(screen.queryByRole("radio", { name: "Registered" })).toBeNull();
+  });
+});

--- a/src/components/acb/AccountTypeMarker.tsx
+++ b/src/components/acb/AccountTypeMarker.tsx
@@ -1,0 +1,60 @@
+import { Group, SegmentedControl, Stack, Text, Title } from "@mantine/core";
+import type { AccountRegistrationOverrides } from "@/utils/acb/parser";
+
+type AccountTypeMarkerAccount = {
+  accountId: string;
+  accountType: string;
+  detectedRegistered: boolean;
+};
+
+type AccountTypeMarkerProps = {
+  accounts: AccountTypeMarkerAccount[];
+  overrides: AccountRegistrationOverrides;
+  onChange: (accountId: string, value: AccountRegistrationOverrides[string]) => void;
+};
+
+function accountName(accountId: string): string {
+  return accountId === "" ? "Unknown account" : accountId;
+}
+
+const AccountTypeMarker = ({ accounts, overrides, onChange }: AccountTypeMarkerProps) => {
+  const unknownAccounts = accounts.filter((account) => account.accountType === "");
+  const knownAccounts = accounts.filter((account) => account.accountType !== "");
+
+  return (
+    <Stack gap="sm">
+      <Title order={2} fz="lg">
+        Account types
+      </Title>
+      <Text c="dimmed" size="sm">
+        Registered accounts (RRSP/TFSA/FHSA) are excluded from ACB.
+      </Text>
+      {unknownAccounts.map((account) => (
+        <Group key={account.accountId} justify="space-between" gap="md" wrap="wrap">
+          <Text fw={600}>{accountName(account.accountId)}</Text>
+          <SegmentedControl
+            aria-label={`${accountName(account.accountId)} account type`}
+            data={[
+              { value: "nonRegistered", label: "Non-registered" },
+              { value: "registered", label: "Registered" },
+            ]}
+            value={overrides[account.accountId] ?? "nonRegistered"}
+            onChange={(value) =>
+              onChange(account.accountId, value as AccountRegistrationOverrides[string])
+            }
+          />
+        </Group>
+      ))}
+      {knownAccounts.map((account) => (
+        <Group key={`${account.accountId}:${account.accountType}`} justify="space-between" gap="md">
+          <Text c="dimmed">{accountName(account.accountId)}</Text>
+          <Text c="dimmed" size="sm">
+            {account.detectedRegistered ? "Registered" : "Non-registered"} (detected)
+          </Text>
+        </Group>
+      ))}
+    </Stack>
+  );
+};
+
+export default AccountTypeMarker;

--- a/src/components/acb/FileUpload.tsx
+++ b/src/components/acb/FileUpload.tsx
@@ -31,10 +31,10 @@ const FileUpload = ({ files, onFilesAdded, onRemoveFile, onPreview }: FileUpload
     <Stack gap="xs">
       <FileInput
         key={inputKey}
-        label="Wealthsimple activity export (CSV)"
-        description="Non-registered account activity exports. Select one or more files covering distinct date ranges — each upload adds to the list below. Parsed entirely in your browser — nothing is uploaded."
-        placeholder="Add CSV file(s)"
-        accept=".csv,text/csv"
+        label="Wealthsimple, Questrade, or IBKR activity export (CSV or XLSX)"
+        description="Select one or more files from supported brokers covering distinct date ranges — each upload adds to the list below. Parsed entirely in your browser — nothing is uploaded."
+        placeholder="Add CSV or XLSX file(s)"
+        accept=".csv,.xlsx,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         multiple
         onChange={(selected) => {
           if (selected.length > 0) onFilesAdded(selected);

--- a/src/components/acb/Main.tsx
+++ b/src/components/acb/Main.tsx
@@ -1,5 +1,17 @@
 import { useState } from "react";
-import { Alert, Container, List, Paper, Stack, Table, Tabs, Text, Title } from "@mantine/core";
+import {
+  Alert,
+  Container,
+  List,
+  Paper,
+  SegmentedControl,
+  Stack,
+  Table,
+  Tabs,
+  Text,
+  Title,
+} from "@mantine/core";
+import AccountTypeMarker from "./AccountTypeMarker";
 import AccountView from "./AccountView";
 import FilePreviewModal from "./FilePreviewModal";
 import FileUpload, { type UploadedFileSummary } from "./FileUpload";
@@ -16,9 +28,11 @@ import {
   groupByAccount,
   hasMixedCurrencies,
   parseFiles,
+  resolveRegistered,
   sumOpeningLot,
   t3NetAdjustment,
   transferLotsForSymbol,
+  type AccountRegistrationOverrides,
   type AcbTransaction,
   type AccountGroup,
   type OpeningLotEntries,
@@ -27,9 +41,19 @@ import {
   type T3Slips,
 } from "@/utils/acb/parser";
 
-/** True when the transaction belongs to a registered account (TFSA/RRSP/FHSA). */
-function isRegisteredTransaction(tx: AcbTransaction): boolean {
-  return /tfsa|rrsp|fhsa/i.test(tx.accountType ?? "");
+type BrokerKey = NonNullable<AcbTransaction["broker"]>;
+type FileBroker = BrokerKey | "unknown";
+
+const BROKER_ORDER: BrokerKey[] = ["wealthsimple", "questrade", "ibkr"];
+
+const BROKER_LABELS: Record<BrokerKey, string> = {
+  wealthsimple: "Wealthsimple",
+  questrade: "Questrade",
+  ibkr: "IBKR",
+};
+
+function fileBroker(file: ParsedFile): FileBroker {
+  return file.transactions[0]?.broker ?? "unknown";
 }
 
 /** "TYPE · ID" label for an account group, or "Unknown account". */
@@ -67,6 +91,8 @@ const Main = () => {
   const [transferModalSymbol, setTransferModalSymbol] = useState<string | null>(null);
   const [previewFileIndex, setPreviewFileIndex] = useState<number | null>(null);
   const [activeTab, setActiveTab] = useState<string | null>("holdings");
+  const [activeBroker, setActiveBroker] = useState<string | null>(null);
+  const [accountOverrides, setAccountOverrides] = useState<AccountRegistrationOverrides>({});
 
   async function handleFilesAdded(newFiles: File[]) {
     const { parsed, errors } = await parseFiles(newFiles);
@@ -91,8 +117,8 @@ const Main = () => {
     rowIndex: number,
     patch: Partial<AcbTransaction>,
   ) {
-    // Holdings, overlap detection, and margin interest are all derived from
-    // loadedFiles below, so they recompute automatically on this update.
+    // Holdings, overlap detection, and margin interest derive from loadedFiles
+    // below, so they recompute automatically on this update.
     setLoadedFiles((prev) =>
       prev.map((file, i) =>
         i === fileIndex
@@ -141,9 +167,23 @@ const Main = () => {
   }
 
   const hasFiles = loadedFiles.length > 0;
+  const presentBrokers = new Set(loadedFiles.map(fileBroker));
+  const availableBrokers = BROKER_ORDER.filter((broker) => presentBrokers.has(broker));
+  const effectiveBroker =
+    activeBroker !== null && availableBrokers.includes(activeBroker as BrokerKey)
+      ? activeBroker
+      : (availableBrokers[0] ?? null);
+  const activeFiles =
+    effectiveBroker === null
+      ? []
+      : loadedFiles.filter((file) => fileBroker(file) === effectiveBroker);
 
-  // Merge all files into one chronologically sorted transaction list.
-  const transactions = loadedFiles
+  function isRegisteredTransaction(tx: AcbTransaction): boolean {
+    return resolveRegistered(tx.accountId ?? "", tx.accountType ?? "", accountOverrides);
+  }
+
+  // Merge active brokerage files into one chronologically sorted transaction list.
+  const transactions = activeFiles
     .flatMap((file) => file.transactions)
     .sort((a, b) => (a.date ?? "").localeCompare(b.date ?? ""));
   // ACB pools across all of a taxpayer's non-registered accounts (CRA rule),
@@ -153,12 +193,24 @@ const Main = () => {
   const holdings = computeHoldings(nonRegisteredTransactions);
   const visibleHoldings = holdings.filter((h) => h.shares > 0);
   const mixedCurrencies = hasMixedCurrencies(transactions);
-  const overlappingFiles = detectOverlappingFiles(loadedFiles.map((file) => file.transactions));
+  const overlappingFiles = detectOverlappingFiles(activeFiles.map((file) => file.transactions));
   const marginInterest = computeMarginInterest(nonRegisteredTransactions);
   const marginYears = Object.keys(marginInterest)
     .map(Number)
     .sort((a, b) => a - b);
-  const accountGroups = groupByAccount(transactions);
+  const accountGroups = groupByAccount(transactions, accountOverrides);
+  const accountTypeMarkerAccounts = accountGroups.map((group) => ({
+    accountId: group.accountId,
+    accountType: group.accountType,
+    detectedRegistered: group.isRegistered,
+  }));
+  const hasUnknownAccountTypes = accountTypeMarkerAccounts.some(
+    (account) => account.accountType === "",
+  );
+  const showAccountTypeMarker = effectiveBroker === "ibkr" && hasUnknownAccountTypes;
+  const hasDefaultedUnknownAccountTypes = accountTypeMarkerAccounts.some(
+    (account) => account.accountType === "" && accountOverrides[account.accountId] === undefined,
+  );
   // Total opening-lot ACB per symbol, summed across its transfer lots — the
   // single number `applyAdjustments` and HoldingsTable consume.
   const openingLotTotals: Record<string, number> = {};
@@ -176,7 +228,9 @@ const Main = () => {
     0,
   );
   const fileSummaries: UploadedFileSummary[] = loadedFiles.map((file) => {
-    const fileRegisteredAccounts = groupByAccount(file.transactions).filter((g) => g.isRegistered);
+    const fileRegisteredAccounts = groupByAccount(file.transactions, accountOverrides).filter(
+      (g) => g.isRegistered,
+    );
     const excludedLabels = fileRegisteredAccounts
       .map(accountLabel)
       .filter((label) => label !== "Unknown account");
@@ -323,6 +377,17 @@ const Main = () => {
             </Text>
           </Alert>
         )}
+        {hasFiles && effectiveBroker !== null && availableBrokers.length > 1 && (
+          <SegmentedControl
+            aria-label="Brokerage"
+            data={availableBrokers.map((broker) => ({
+              value: broker,
+              label: BROKER_LABELS[broker],
+            }))}
+            value={effectiveBroker}
+            onChange={setActiveBroker}
+          />
+        )}
         {hasFiles && (
           <SummaryBar
             totalCostBasis={totalCostBasis}
@@ -330,6 +395,27 @@ const Main = () => {
             transactionCount={nonRegisteredTransactions.length}
             dateRange={dateRangeOf(nonRegisteredTransactions)}
           />
+        )}
+        {hasFiles && showAccountTypeMarker && (
+          <Paper withBorder p="md" radius="md">
+            <Stack gap="md">
+              {hasDefaultedUnknownAccountTypes && (
+                <Alert color="yellow" title="Mark account types">
+                  <Text size="sm">
+                    IBKR consolidated statements do not say which sub-account is registered. Mark
+                    each account so RRSP/TFSA/FHSA accounts are excluded from ACB.
+                  </Text>
+                </Alert>
+              )}
+              <AccountTypeMarker
+                accounts={accountTypeMarkerAccounts}
+                overrides={accountOverrides}
+                onChange={(accountId, value) =>
+                  setAccountOverrides((prev) => ({ ...prev, [accountId]: value }))
+                }
+              />
+            </Stack>
+          </Paper>
         )}
         {hasFiles && (
           <Tabs value={activeTab} onChange={setActiveTab}>

--- a/src/utils/acb/parser.test.ts
+++ b/src/utils/acb/parser.test.ts
@@ -8,13 +8,18 @@ import {
   detectOverlappingFiles,
   groupByAccount,
   hasMixedCurrencies,
+  parseActivityText,
   parseFiles,
+  parseIbkrCsv,
+  parseQuestradeRows,
   parseWealthsimpleCsv,
+  resolveRegistered,
   sumOpeningLot,
   t3NetAdjustment,
   transferLotsForSymbol,
   type AcbTransaction,
 } from "./parser";
+import { readSheetRows } from "./xlsx";
 
 const HEADER = "Date,Symbol,Quantity,Price,Type,Description";
 
@@ -27,6 +32,85 @@ const WS_HEADER =
 
 function wsCsv(...rows: string[]): string {
   return [WS_HEADER, ...rows].join("\n");
+}
+
+function storedXlsx(): ArrayBuffer {
+  const encoder = new TextEncoder();
+  const files = [
+    {
+      name: "xl/workbook.xml",
+      text: '<x:workbook xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><x:sheets><x:sheet name="Sheet1" sheetId="1" r:id="rId1" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" /></x:sheets></x:workbook>',
+    },
+    {
+      name: "xl/_rels/workbook.xml.rels",
+      text: '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="/xl/worksheets/sheet.xml" Id="rId1" /></Relationships>',
+    },
+    {
+      name: "xl/worksheets/sheet.xml",
+      text: '<x:worksheet xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><x:sheetData><x:row><x:c r="A1" t="str"><x:v>Symbol</x:v></x:c><x:c r="B1" t="str"><x:v>Name</x:v></x:c></x:row><x:row><x:c r="A2" t="str"><x:v>XSB.TO</x:v></x:c><x:c r="B2" t="str"><x:v>Bond &amp; Cash</x:v></x:c></x:row></x:sheetData></x:worksheet>',
+    },
+  ];
+  const bytes: number[] = [];
+  const central: number[] = [];
+  const write16 = (target: number[], value: number) => {
+    target.push(value & 0xff, (value >> 8) & 0xff);
+  };
+  const write32 = (target: number[], value: number) => {
+    target.push(value & 0xff, (value >> 8) & 0xff, (value >> 16) & 0xff, (value >> 24) & 0xff);
+  };
+  const append = (target: number[], data: Uint8Array) => {
+    for (const byte of data) target.push(byte);
+  };
+
+  for (const file of files) {
+    const name = encoder.encode(file.name);
+    const data = encoder.encode(file.text);
+    const localOffset = bytes.length;
+    write32(bytes, 0x04034b50);
+    write16(bytes, 20);
+    write16(bytes, 0);
+    write16(bytes, 0);
+    write16(bytes, 0);
+    write16(bytes, 0);
+    write32(bytes, 0);
+    write32(bytes, data.length);
+    write32(bytes, data.length);
+    write16(bytes, name.length);
+    write16(bytes, 0);
+    append(bytes, name);
+    append(bytes, data);
+
+    write32(central, 0x02014b50);
+    write16(central, 20);
+    write16(central, 20);
+    write16(central, 0);
+    write16(central, 0);
+    write16(central, 0);
+    write16(central, 0);
+    write32(central, 0);
+    write32(central, data.length);
+    write32(central, data.length);
+    write16(central, name.length);
+    write16(central, 0);
+    write16(central, 0);
+    write16(central, 0);
+    write16(central, 0);
+    write32(central, 0);
+    write32(central, localOffset);
+    append(central, name);
+  }
+
+  const centralOffset = bytes.length;
+  bytes.push(...central);
+  write32(bytes, 0x06054b50);
+  write16(bytes, 0);
+  write16(bytes, 0);
+  write16(bytes, files.length);
+  write16(bytes, files.length);
+  write32(bytes, central.length);
+  write32(bytes, centralOffset);
+  write16(bytes, 0);
+  return new Uint8Array(bytes).buffer;
 }
 
 describe("parseWealthsimpleCsv (legacy Type column)", () => {
@@ -47,6 +131,7 @@ describe("parseWealthsimpleCsv (legacy Type column)", () => {
       quantity: 10,
       price: 40,
       type: "buy",
+      broker: "wealthsimple",
       currency: "CAD",
       date: "",
       rawActivityType: "buy",
@@ -80,6 +165,7 @@ describe("parseWealthsimpleCsv (legacy Type column)", () => {
       quantity: 2,
       price: 25.5,
       type: "buy",
+      broker: "wealthsimple",
       currency: "CAD",
       date: "",
       rawActivityType: "buy",
@@ -175,6 +261,7 @@ describe("parseWealthsimpleCsv (Wealthsimple activity columns)", () => {
       quantity: 10,
       price: 40,
       type: "buy",
+      broker: "wealthsimple",
       currency: "CAD",
       date: "2025-01-02",
       rawActivityType: "Trade",
@@ -240,6 +327,309 @@ describe("parseWealthsimpleCsv (Wealthsimple activity columns)", () => {
     expect(result.error).toContain("unit_price");
     expect(result.error).toContain("activity_type");
   });
+});
+
+describe("parseQuestradeRows", () => {
+  const rows = [
+    [
+      "Transaction Date",
+      "Settlement Date",
+      "Action",
+      "Symbol",
+      "Description",
+      "Quantity",
+      "Price",
+      "Gross Amount",
+      "Commission",
+      "Net Amount",
+      "Currency",
+      "Account #",
+      "Activity Type",
+      "Account Type",
+    ],
+    [
+      "2026-06-01 12:00:00 AM",
+      "2026-06-01 12:00:00 AM",
+      "",
+      "XSB.TO",
+      "Distribution",
+      "0.00000",
+      "0.06000000",
+      "0.00",
+      "0.00",
+      "25.60",
+      "CAD",
+      "40148448",
+      "Dividends",
+      "Individual cash",
+    ],
+    [
+      "2026-04-17 12:00:00 AM",
+      "2026-04-17 12:00:00 AM",
+      "DEP",
+      "",
+      "TD DIR DEP",
+      "0.00000",
+      "0.00000000",
+      "0.00",
+      "0.00",
+      "10000.00",
+      "CAD",
+      "40148448",
+      "Deposits",
+      "Individual cash",
+    ],
+    [
+      "2026-04-17 12:00:00 AM",
+      "2026-04-20 12:00:00 AM",
+      "Buy",
+      "XSB.TO",
+      "ISHARES CORE CANADIAN SHORT TERM BOND INDEX ETF",
+      "71.00000",
+      "26.95000000",
+      "-1913.45",
+      "0.00",
+      "-1913.45",
+      "CAD",
+      "40148448",
+      "Trades",
+      "Individual cash",
+    ],
+    [
+      "2026-04-17 12:00:00 AM",
+      "2026-04-20 12:00:00 AM",
+      "Buy",
+      "XSB.TO",
+      "ISHARES CORE CANADIAN SHORT TERM BOND INDEX ETF",
+      "300.00000",
+      "26.95000000",
+      "-8085.00",
+      "0.00",
+      "-8085.00",
+      "CAD",
+      "40148448",
+      "Trades",
+      "Individual cash",
+    ],
+    [
+      "2026-03-13 12:00:00 AM",
+      "2026-03-16 12:00:00 AM",
+      "Buy",
+      "XEF.TO",
+      "ISHARES CORE MSCI EAFE IMI INDEX ETF",
+      "19.00000",
+      "46.59000000",
+      "-885.21",
+      "0.00",
+      "-885.21",
+      "CAD",
+      "53670632",
+      "Trades",
+      "Individual FHSA",
+    ],
+    [
+      "2026-04-01 12:00:00 AM",
+      "2026-04-02 12:00:00 AM",
+      "Buy",
+      "XEF.TO",
+      "ISHARES CORE MSCI EAFE IMI INDEX ETF",
+      "63.00000",
+      "48.16000000",
+      "-3034.08",
+      "0.00",
+      "-3034.08",
+      "CAD",
+      "53670632",
+      "Trades",
+      "Individual FHSA",
+    ],
+    [
+      "2026-04-09 12:00:00 AM",
+      "2026-04-10 12:00:00 AM",
+      "Buy",
+      "XEF.TO",
+      "ISHARES CORE MSCI EAFE IMI INDEX ETF",
+      "61.00000",
+      "49.12000000",
+      "-2996.32",
+      "0.00",
+      "-2996.32",
+      "CAD",
+      "53670632",
+      "Trades",
+      "Individual FHSA",
+    ],
+    [
+      "2026-04-10 12:00:00 AM",
+      "2026-04-13 12:00:00 AM",
+      "Buy",
+      "XEF.TO",
+      "ISHARES CORE MSCI EAFE IMI INDEX ETF",
+      "75.00000",
+      "49.82000000",
+      "-3736.50",
+      "0.00",
+      "-3736.50",
+      "CAD",
+      "53670632",
+      "Trades",
+      "Individual FHSA",
+    ],
+  ];
+
+  it("parses Questrade activity rows and keeps raw symbols", () => {
+    const result = parseQuestradeRows(rows);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const holdings = computeHoldings(result.transactions);
+    expect(holdings.find((holding) => holding.symbol === "XSB.TO")).toMatchObject({
+      shares: 371,
+      costBasis: 1913.45 + 8085,
+    });
+    expect(holdings.find((holding) => holding.symbol === "XEF.TO")?.shares).toBe(218);
+    expect(holdings.find((holding) => holding.symbol === "")).toBeUndefined();
+    expect(result.transactions.some((tx) => tx.type === "dividend")).toBe(true);
+    expect(result.transactions.every((tx) => tx.broker === "questrade")).toBe(true);
+  });
+
+  it("tags Questrade FHSA rows as registered", () => {
+    const result = parseQuestradeRows(rows);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const groups = groupByAccount(result.transactions);
+    const fhsa = groups.find((group) => group.accountType === "Individual FHSA");
+    expect(fhsa?.isRegistered).toBe(true);
+  });
+});
+
+describe("parseIbkrCsv", () => {
+  const ibkrText = [
+    "Statement,Data,BrokerName,Interactive Brokers Canada Inc.",
+    "Account Information,Header,Field Name,Field Value",
+    'Account Information,Data,Account,"U23432652 (Custom Consolidated)"',
+    'Account Information,Data,Accounts Included,"U23432652, U23432845"',
+    "Account Information,Data,Account Type,Individual",
+    "Account Information,Data,Customer Type,Registered Retirement Savings Plan",
+    "Trades,Header,DataDiscriminator,Asset Category,Currency,Account,Symbol,Date/Time,Quantity,T. Price,C. Price,Proceeds,Comm/Fee,Basis,Realized P/L,MTM P/L,Code",
+    'Trades,Data,Order,Stocks,CAD,U23432845,VCN,"2026-04-17, 11:23:59",836,69.78,69.87,-58336.08,-8.36,58344.44,0,75.24,O;P',
+    "Trades,SubTotal,,Stocks,CAD,VCN,,,836,,,-58336.08,-8.36,58344.44,0,75.24,",
+    'Trades,Data,Order,Stocks,CAD,U23432845,VEQT,"2026-04-17, 11:08:43",109,57.71,57.71,-6290.39,-1.09,6291.48,0,0,O;P',
+    'Trades,Data,Order,Stocks,USD,U23432652,VT,"2026-04-16, 11:20:06",70.2835,148.839994756,148.79,-10460.99577145,-1,10461.99577145,0,-3.5138,O;P;RPA',
+    'Trades,Data,Order,Forex,CAD,U23432652,USD.CAD,"2026-04-16, 09:16:28","10,462.66",1.37195,,-14354.246387,-2.7484,,,-16.217123,',
+  ].join("\n");
+
+  it("parses IBKR stock trades and uses Basis as cost", () => {
+    const result = parseIbkrCsv(ibkrText);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const holdings = computeHoldings(result.transactions);
+    expect(holdings.find((holding) => holding.symbol === "VCN")).toMatchObject({
+      shares: 836,
+      costBasis: 58344.44,
+    });
+    expect(holdings.find((holding) => holding.symbol === "VEQT")).toMatchObject({
+      shares: 109,
+      costBasis: 6291.48,
+    });
+    expect(holdings.find((holding) => holding.symbol === "VT")).toMatchObject({
+      shares: 70.2835,
+      costBasis: 10461.99577145,
+    });
+    expect(holdings.find((holding) => holding.symbol === "USD.CAD")).toBeUndefined();
+    expect(result.transactions.every((tx) => tx.broker === "ibkr")).toBe(true);
+  });
+
+  it("keeps consolidated account registration unknown per trade", () => {
+    const result = parseIbkrCsv(ibkrText);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.transactions.find((tx) => tx.symbol === "VCN")?.accountId).toBe("U23432845");
+    expect(result.transactions.find((tx) => tx.symbol === "VEQT")?.accountId).toBe("U23432845");
+    const vt = result.transactions.find((tx) => tx.symbol === "VT");
+    expect(vt?.accountId).toBe("U23432652");
+    expect(vt?.currency).toBe("USD");
+    expect(hasMixedCurrencies(result.transactions)).toBe(true);
+    expect(result.transactions.every((tx) => (tx.accountType ?? "") === "")).toBe(true);
+    const groups = groupByAccount(result.transactions);
+    expect(groups).toHaveLength(2);
+    expect(groups.map((group) => group.accountId).sort()).toEqual(["U23432652", "U23432845"]);
+    expect(groups.every((group) => group.accountType === "")).toBe(true);
+    expect(groups.every((group) => group.isRegistered === false)).toBe(true);
+  });
+
+  it("applies statement account type for single-account IBKR exports", () => {
+    const result = parseIbkrCsv(
+      [
+        "Statement,Data,BrokerName,Interactive Brokers Canada Inc.",
+        "Account Information,Header,Field Name,Field Value",
+        "Account Information,Data,Account,U23432652",
+        "Account Information,Data,Accounts Included,U23432652",
+        "Account Information,Data,Account Type,Individual",
+        "Account Information,Data,Customer Type,Registered Retirement Savings Plan",
+        "Trades,Header,DataDiscriminator,Asset Category,Currency,Account,Symbol,Date/Time,Quantity,T. Price,C. Price,Proceeds,Comm/Fee,Basis,Realized P/L,MTM P/L,Code",
+        'Trades,Data,Order,Stocks,USD,U23432652,VT,"2026-04-16, 11:20:06",70.2835,148.839994756,148.79,-10460.99577145,-1,10461.99577145,0,-3.5138,O;P;RPA',
+      ].join("\n"),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.transactions[0]).toMatchObject({
+      accountId: "U23432652",
+      accountType: "Registered Retirement Savings Plan",
+      broker: "ibkr",
+    });
+    const groups = groupByAccount(result.transactions);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      accountId: "U23432652",
+      accountType: "Registered Retirement Savings Plan",
+      isRegistered: true,
+    });
+  });
+});
+
+describe("parseActivityText", () => {
+  it("sniffs IBKR statements", () => {
+    const result = parseActivityText(
+      [
+        "Statement,Data,Title,Activity Statement",
+        "Account Information,Data,Customer Type,Registered Retirement Savings Plan",
+        "Trades,Header,DataDiscriminator,Asset Category,Currency,Account,Symbol,Date/Time,Quantity,T. Price,C. Price,Proceeds,Comm/Fee,Basis,Realized P/L,MTM P/L,Code",
+        'Trades,Data,Order,Stocks,CAD,U1,VCN,"2026-04-17, 11:23:59",1,69.78,69.87,-69.78,-1,70.78,0,0,O;P',
+      ].join("\n"),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.transactions[0].symbol).toBe("VCN");
+  });
+
+  it("leaves Wealthsimple parsing unchanged", () => {
+    const text = wsCsv(
+      "2025-01-02,2025-01-03,acc1,non-registered,Trade,BUY,LONG,VEQT,Vanguard All-Equity,CAD,10,40.00,0,-400.00",
+    );
+    const result = parseActivityText(text);
+    const expected = parseWealthsimpleCsv(text);
+    expect(result).toEqual(expected);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.transactions[0]).toMatchObject({
+      symbol: "VEQT",
+      quantity: 10,
+      netCashAmount: -400,
+    });
+  });
+});
+
+describe("readSheetRows", () => {
+  it.skipIf(typeof DecompressionStream === "undefined")(
+    "reads a stored XLSX worksheet",
+    async () => {
+      const rows = await readSheetRows(storedXlsx());
+      expect(rows).toEqual([
+        ["Symbol", "Name"],
+        ["XSB.TO", "Bond & Cash"],
+      ]);
+    },
+  );
 });
 
 describe("hasMixedCurrencies", () => {
@@ -741,6 +1131,30 @@ describe("groupByAccount", () => {
       tx("d", "non-registered"),
     ]);
     expect(groups.map((g) => g.accountId)).toEqual(["b", "d", "a", "c"]);
+  });
+
+  it("uses overrides when grouping consolidated IBKR accounts", () => {
+    const groups = groupByAccount([tx("U123", "", "VT"), tx("U456", "", "VCN")], {
+      U123: "registered",
+    });
+    const registeredById = new Map(groups.map((g) => [g.accountId, g.isRegistered]));
+    expect(registeredById.get("U123")).toBe(true);
+    expect(registeredById.get("U456")).toBe(false);
+  });
+});
+
+describe("resolveRegistered", () => {
+  it("lets a non-registered override win over RRSP account type", () => {
+    expect(resolveRegistered("acc1", "RRSP", { acc1: "nonRegistered" })).toBe(false);
+  });
+
+  it("lets a registered override mark an empty account type", () => {
+    expect(resolveRegistered("acc1", "", { acc1: "registered" })).toBe(true);
+  });
+
+  it("falls back to account type regex without an override", () => {
+    expect(resolveRegistered("acc1", "Registered Retirement Savings Plan")).toBe(true);
+    expect(resolveRegistered("acc2", "")).toBe(false);
   });
 });
 

--- a/src/utils/acb/parser.ts
+++ b/src/utils/acb/parser.ts
@@ -1,4 +1,6 @@
-// Parser for Wealthsimple account activity CSV exports.
+import { readSheetRows } from "./xlsx";
+
+// Parser for brokerage account activity exports.
 //
 // Supports two formats:
 // 1. The real Wealthsimple export with columns
@@ -39,6 +41,8 @@ export type AcbTransaction = {
   accountType?: string;
   /** Parsed `net_cash_amount` column value; undefined when absent. */
   netCashAmount?: number;
+  /** Source brokerage parser that emitted this transaction. */
+  broker?: "wealthsimple" | "questrade" | "ibkr";
 };
 
 /** One T3 slip's ACB-relevant boxes for a single tax year. */
@@ -87,6 +91,20 @@ export type OpeningLotEntries = Record<string, number[]>;
 /** Total opening-lot ACB across a symbol's transfer lots. */
 export function sumOpeningLot(acbs: number[] | undefined): number {
   return (acbs ?? []).reduce((sum, acb) => sum + (acb || 0), 0);
+}
+
+export type AccountRegistrationOverrides = Record<string, "registered" | "nonRegistered">;
+
+/** Resolve registered-account status from user override first, then parser account type. */
+export function resolveRegistered(
+  accountId: string,
+  accountType: string,
+  overrides?: AccountRegistrationOverrides,
+): boolean {
+  if (overrides && accountId in overrides) {
+    return overrides[accountId] === "registered";
+  }
+  return /tfsa|rrsp|fhsa|registered retirement savings plan/i.test(accountType);
 }
 
 /** Net ACB adjustment across all years: sum(box21) − sum(box42). */
@@ -145,6 +163,10 @@ function splitCsvLine(line: string): string[] {
 function parseNumber(field: string | undefined): number {
   const cleaned = (field ?? "").trim().replace(/[$,]/g, "");
   return cleaned === "" ? 0 : Number(cleaned);
+}
+
+function normalizedHeader(field: string): string {
+  return field.trim().toLowerCase().replace(/\s+/g, "");
 }
 
 /**
@@ -248,6 +270,7 @@ export function parseWealthsimpleCsv(text: string): ParseResult {
       quantity: Number.isFinite(quantity) ? quantity : 0,
       price: Number.isFinite(price) ? price : 0,
       type,
+      broker: "wealthsimple",
       currency: rawCurrency === "" ? "CAD" : rawCurrency.toUpperCase(),
       date: field(dateIdx),
       rawActivityType,
@@ -262,6 +285,155 @@ export function parseWealthsimpleCsv(text: string): ParseResult {
   }
 
   return { ok: true, transactions };
+}
+
+export function parseQuestradeRows(rows: string[][]): ParseResult {
+  if (rows.length === 0) {
+    return { ok: false, error: "No transactions found" };
+  }
+
+  const header = rows[0].map(normalizedHeader);
+  const col = (name: string): number => header.indexOf(normalizedHeader(name));
+  const symbolIdx = col("Symbol");
+  const quantityIdx = col("Quantity");
+  const priceIdx = col("Price");
+  const actionIdx = col("Action");
+  const activityTypeIdx = col("Activity Type");
+  const currencyIdx = col("Currency");
+  const dateIdx = col("Transaction Date");
+  const accountIdIdx = col("Account #");
+  const accountTypeIdx = col("Account Type");
+  const netAmountIdx = col("Net Amount");
+
+  const missing: string[] = [];
+  if (symbolIdx === -1) missing.push("Symbol");
+  if (quantityIdx === -1) missing.push("Quantity");
+  if (priceIdx === -1) missing.push("Price");
+  if (actionIdx === -1) missing.push("Action");
+  if (activityTypeIdx === -1) missing.push("Activity Type");
+  if (netAmountIdx === -1) missing.push("Net Amount");
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      error: `Missing required column${missing.length > 1 ? "s" : ""}: ${missing.join(", ")}`,
+    };
+  }
+
+  const transactions: AcbTransaction[] = [];
+  for (const row of rows.slice(1)) {
+    const field = (idx: number): string => (idx === -1 ? "" : (row[idx] ?? "").trim());
+    const rawActivityType = field(activityTypeIdx);
+    const action = field(actionIdx).toLowerCase();
+    let type: AcbTransaction["type"] | null = null;
+    if (action === "buy") type = "buy";
+    else if (action === "sell") type = "sell";
+    else if (rawActivityType.toLowerCase() === "dividends") type = "dividend";
+    if (type === null) continue;
+
+    const symbol = field(symbolIdx);
+    if (!symbol) continue;
+    const quantity = parseNumber(field(quantityIdx));
+    const price = parseNumber(field(priceIdx));
+    const accountId = field(accountIdIdx);
+    const accountType = field(accountTypeIdx);
+    transactions.push({
+      symbol,
+      quantity: Number.isFinite(quantity) ? Math.abs(quantity) : 0,
+      price: Number.isFinite(price) ? price : 0,
+      type,
+      broker: "questrade",
+      currency: field(currencyIdx) === "" ? "CAD" : field(currencyIdx).toUpperCase(),
+      date: field(dateIdx).slice(0, 10),
+      rawActivityType,
+      ...(accountId !== "" ? { accountId } : {}),
+      ...(accountType !== "" ? { accountType } : {}),
+      netCashAmount: parseNumber(field(netAmountIdx)),
+    });
+  }
+
+  if (transactions.length === 0) {
+    return { ok: false, error: "No transactions found" };
+  }
+
+  return { ok: true, transactions };
+}
+
+export function parseIbkrCsv(text: string): ParseResult {
+  const lines = text.split(/\r\n|\r|\n/).filter((line) => line.trim().length > 0);
+  let statementAccountType = "";
+  let statementCustomerType = "";
+  let isConsolidated = false;
+  const transactions: AcbTransaction[] = [];
+
+  for (const line of lines) {
+    const fields = splitCsvLine(line);
+    if (fields[0] === "Account Information" && fields[1] === "Data") {
+      const name = (fields[2] ?? "").trim();
+      const value = fields.slice(3).join(",").trim();
+      if (name === "Account Type" && value !== "") {
+        statementAccountType = value;
+      } else if (name === "Customer Type" && value !== "") {
+        statementCustomerType = value;
+      } else if (name === "Account" && /consolidated/i.test(value)) {
+        isConsolidated = true;
+      } else if (
+        name === "Accounts Included" &&
+        value
+          .split(",")
+          .map((account) => account.trim())
+          .filter(Boolean).length > 1
+      ) {
+        isConsolidated = true;
+      }
+    }
+  }
+
+  const accountType = isConsolidated
+    ? ""
+    : statementCustomerType !== ""
+      ? statementCustomerType
+      : statementAccountType;
+
+  for (const line of lines) {
+    const fields = splitCsvLine(line);
+    if (
+      fields[0] !== "Trades" ||
+      fields[1] !== "Data" ||
+      fields[2] !== "Order" ||
+      fields[3] !== "Stocks"
+    ) {
+      continue;
+    }
+
+    const quantity = parseNumber(fields[8]);
+    const basis = parseNumber(fields[13]);
+    transactions.push({
+      symbol: (fields[6] ?? "").trim(),
+      quantity: Number.isFinite(quantity) ? Math.abs(quantity) : 0,
+      price: parseNumber(fields[9]),
+      type: quantity >= 0 ? "buy" : "sell",
+      broker: "ibkr",
+      currency: ((fields[4] ?? "").trim() || "CAD").toUpperCase(),
+      accountId: (fields[5] ?? "").trim(),
+      date: (fields[7] ?? "").trim().slice(0, 10),
+      rawActivityType: "Trades",
+      ...(accountType !== "" ? { accountType } : {}),
+      netCashAmount: Number.isFinite(basis) ? Math.abs(basis) : 0,
+    });
+  }
+
+  if (transactions.length === 0) {
+    return { ok: false, error: "No transactions found" };
+  }
+
+  return { ok: true, transactions };
+}
+
+export function parseActivityText(text: string): ParseResult {
+  const isIbkr =
+    text.split(/\r\n|\r|\n/).some((line) => line.startsWith("Statement,")) ||
+    text.includes(",DataDiscriminator,");
+  return isIbkr ? parseIbkrCsv(text) : parseWealthsimpleCsv(text);
 }
 
 /**
@@ -425,7 +597,7 @@ export type AccountGroup = {
   accountId: string;
   /** From the `account_type` column; "" for the legacy format. */
   accountType: string;
-  /** True when accountType contains "TFSA", "RRSP", or "FHSA". */
+  /** True when accountType contains "TFSA", "RRSP", "FHSA", or the IBKR RRSP long name. */
   isRegistered: boolean;
   transactions: AcbTransaction[];
 };
@@ -435,7 +607,10 @@ export type AccountGroup = {
  * each group's transaction order. Non-registered accounts sort before
  * registered ones (TFSA / RRSP / FHSA, case-insensitive).
  */
-export function groupByAccount(transactions: AcbTransaction[]): AccountGroup[] {
+export function groupByAccount(
+  transactions: AcbTransaction[],
+  overrides?: AccountRegistrationOverrides,
+): AccountGroup[] {
   const groups = new Map<string, AccountGroup>();
   for (const tx of transactions) {
     const accountId = tx.accountId ?? "";
@@ -446,7 +621,7 @@ export function groupByAccount(transactions: AcbTransaction[]): AccountGroup[] {
       group = {
         accountId,
         accountType,
-        isRegistered: /tfsa|rrsp|fhsa/i.test(accountType),
+        isRegistered: resolveRegistered(accountId, accountType, overrides),
         transactions: [],
       };
       groups.set(key, group);
@@ -551,14 +726,24 @@ export async function parseFiles(
   const parsed: ParsedFile[] = [];
   const errors: string[] = [];
   for (const file of files) {
-    let text: string;
-    try {
-      text = await file.text();
-    } catch {
-      errors.push(`${file.name}: could not read the file.`);
-      continue;
-    }
-    const result = parseWealthsimpleCsv(text);
+    const isSpreadsheet =
+      /\.xlsx$/i.test(file.name) ||
+      file.type === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    const result = isSpreadsheet
+      ? await (async (): Promise<ParseResult> => {
+          try {
+            return parseQuestradeRows(await readSheetRows(await file.arrayBuffer()));
+          } catch {
+            return { ok: false, error: "could not read the spreadsheet." };
+          }
+        })()
+      : await (async (): Promise<ParseResult> => {
+          try {
+            return parseActivityText(await file.text());
+          } catch {
+            return { ok: false, error: "could not read the file." };
+          }
+        })();
     if (result.ok) {
       parsed.push({ name: file.name, transactions: result.transactions });
     } else {

--- a/src/utils/acb/xlsx.ts
+++ b/src/utils/acb/xlsx.ts
@@ -1,0 +1,201 @@
+type ZipEntry = {
+  compressionMethod: number;
+  compressedSize: number;
+  localOffset: number;
+};
+
+const textDecoder = new TextDecoder();
+
+function findEndOfCentralDirectory(bytes: Uint8Array): number {
+  const minOffset = Math.max(0, bytes.length - 22 - 0xffff);
+  for (let offset = bytes.length - 22; offset >= minOffset; offset--) {
+    if (
+      bytes[offset] === 0x50 &&
+      bytes[offset + 1] === 0x4b &&
+      bytes[offset + 2] === 0x05 &&
+      bytes[offset + 3] === 0x06
+    ) {
+      return offset;
+    }
+  }
+  throw new Error("Missing ZIP central directory");
+}
+
+function readZipEntries(bytes: Uint8Array): Map<string, ZipEntry> {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const eocdOffset = findEndOfCentralDirectory(bytes);
+  const entryCount = view.getUint16(eocdOffset + 10, true);
+  let offset = view.getUint32(eocdOffset + 16, true);
+  const entries = new Map<string, ZipEntry>();
+
+  for (let i = 0; i < entryCount; i++) {
+    if (view.getUint32(offset, true) !== 0x02014b50) {
+      throw new Error("Invalid ZIP central directory");
+    }
+    const compressionMethod = view.getUint16(offset + 10, true);
+    const compressedSize = view.getUint32(offset + 20, true);
+    const fileNameLength = view.getUint16(offset + 28, true);
+    const extraLength = view.getUint16(offset + 30, true);
+    const commentLength = view.getUint16(offset + 32, true);
+    const localOffset = view.getUint32(offset + 42, true);
+    const nameStart = offset + 46;
+    const name = textDecoder.decode(bytes.slice(nameStart, nameStart + fileNameLength));
+    entries.set(name, { compressionMethod, compressedSize, localOffset });
+    offset = nameStart + fileNameLength + extraLength + commentLength;
+  }
+
+  return entries;
+}
+
+async function readZipText(bytes: Uint8Array, entries: Map<string, ZipEntry>, name: string) {
+  const entry = entries.get(name);
+  if (!entry) return undefined;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (view.getUint32(entry.localOffset, true) !== 0x04034b50) {
+    throw new Error("Invalid ZIP local header");
+  }
+  const localNameLength = view.getUint16(entry.localOffset + 26, true);
+  const localExtraLength = view.getUint16(entry.localOffset + 28, true);
+  const dataStart = entry.localOffset + 30 + localNameLength + localExtraLength;
+  const raw = bytes.slice(dataStart, dataStart + entry.compressedSize);
+
+  if (entry.compressionMethod === 0) {
+    return textDecoder.decode(raw);
+  }
+  if (entry.compressionMethod === 8) {
+    const stream = new Blob([raw]).stream().pipeThrough(new DecompressionStream("deflate-raw"));
+    const inflated = await new Response(stream).arrayBuffer();
+    return textDecoder.decode(inflated);
+  }
+  throw new Error("Unsupported ZIP compression method");
+}
+
+function decodeXml(text: string): string {
+  return text
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex: string) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec: string) => String.fromCodePoint(Number(dec)))
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/&amp;/g, "&");
+}
+
+function attr(xml: string, name: string): string | undefined {
+  const match = new RegExp(`(?:^|\\s)${name}="([^"]*)"`).exec(xml);
+  return match ? decodeXml(match[1]) : undefined;
+}
+
+function tagText(xml: string, tag: string): string | undefined {
+  const match = new RegExp(
+    `<(?:(?:\\w+):)?${tag}\\b[^>]*>([\\s\\S]*?)<\\/(?:(?:\\w+):)?${tag}>`,
+  ).exec(xml);
+  return match ? decodeXml(match[1]) : undefined;
+}
+
+function allTagText(xml: string, tag: string): string {
+  const parts: string[] = [];
+  const regex = new RegExp(
+    `<(?:(?:\\w+):)?${tag}\\b[^>]*>([\\s\\S]*?)<\\/(?:(?:\\w+):)?${tag}>`,
+    "g",
+  );
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(xml))) {
+    parts.push(decodeXml(match[1]));
+  }
+  return parts.join("");
+}
+
+function parseSharedStrings(xml: string | undefined): string[] {
+  if (!xml) return [];
+  const strings: string[] = [];
+  const regex = /<(?:(?:\w+):)?si\b[^>]*>([\s\S]*?)<\/(?:(?:\w+):)?si>/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(xml))) {
+    strings.push(allTagText(match[1], "t"));
+  }
+  return strings;
+}
+
+function columnIndex(ref: string | undefined, fallback: number): number {
+  const letters = ref?.match(/^[A-Za-z]+/)?.[0];
+  if (!letters) return fallback;
+  let index = 0;
+  for (const letter of letters.toUpperCase()) {
+    index = index * 26 + letter.charCodeAt(0) - 64;
+  }
+  return index - 1;
+}
+
+function cellValue(cell: string, sharedStrings: string[]): string {
+  const openTag = cell.match(/^<(?:(?:\w+):)?c\b([^>]*)>/)?.[1] ?? "";
+  const type = attr(openTag, "t");
+  if (type === "s") {
+    const index = Number(tagText(cell, "v") ?? "");
+    return Number.isInteger(index) ? (sharedStrings[index] ?? "") : "";
+  }
+  if (type === "inlineStr" || cell.includes("<is") || cell.includes(":is")) {
+    return allTagText(cell, "t");
+  }
+  return tagText(cell, "v") ?? "";
+}
+
+function parseRows(xml: string, sharedStrings: string[]): string[][] {
+  const rows: string[][] = [];
+  const rowRegex = /<(?:(?:\w+):)?row\b[^>]*>([\s\S]*?)<\/(?:(?:\w+):)?row>/g;
+  const cellRegex = /<(?:(?:\w+):)?c\b[^>]*>[\s\S]*?<\/(?:(?:\w+):)?c>/g;
+  let rowMatch: RegExpExecArray | null;
+  while ((rowMatch = rowRegex.exec(xml))) {
+    const row: string[] = [];
+    let nextColumn = 0;
+    let cellMatch: RegExpExecArray | null;
+    while ((cellMatch = cellRegex.exec(rowMatch[1]))) {
+      const cell = cellMatch[0];
+      const openTag = cell.match(/^<(?:(?:\w+):)?c\b([^>]*)>/)?.[1] ?? "";
+      const index = columnIndex(attr(openTag, "r"), nextColumn);
+      while (row.length < index) row.push("");
+      row[index] = cellValue(cell, sharedStrings);
+      nextColumn = index + 1;
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+function resolveWorksheetPath(
+  entries: Map<string, ZipEntry>,
+  workbookXml: string | undefined,
+  relsXml: string | undefined,
+): string {
+  if (entries.has("xl/worksheets/sheet1.xml")) return "xl/worksheets/sheet1.xml";
+  const sheetMatch = workbookXml?.match(/<(?:(?:\w+):)?sheet\b[^>]*(?:\w+:)?id="([^"]+)"/);
+  const relId = sheetMatch?.[1];
+  if (relId && relsXml) {
+    const relRegex = /<Relationship\b[^>]*>/g;
+    let relMatch: RegExpExecArray | null;
+    while ((relMatch = relRegex.exec(relsXml))) {
+      const rel = relMatch[0];
+      if (attr(rel, "Id") !== relId) continue;
+      const target = attr(rel, "Target");
+      if (target?.startsWith("/")) return target.slice(1);
+      if (target) return `xl/${target}`;
+    }
+  }
+  const firstWorksheet = [...entries.keys()].find((name) =>
+    /^xl\/worksheets\/[^/]+\.xml$/.test(name),
+  );
+  if (firstWorksheet) return firstWorksheet;
+  throw new Error("Missing worksheet");
+}
+
+export async function readSheetRows(buf: ArrayBuffer): Promise<string[][]> {
+  const bytes = new Uint8Array(buf);
+  const entries = readZipEntries(bytes);
+  const workbookXml = await readZipText(bytes, entries, "xl/workbook.xml");
+  const relsXml = await readZipText(bytes, entries, "xl/_rels/workbook.xml.rels");
+  const sharedStringsXml = await readZipText(bytes, entries, "xl/sharedStrings.xml");
+  const worksheetPath = resolveWorksheetPath(entries, workbookXml, relsXml);
+  const sheetXml = await readZipText(bytes, entries, worksheetPath);
+  if (!sheetXml) throw new Error("Missing worksheet");
+  return parseRows(sheetXml, parseSharedStrings(sharedStringsXml));
+}


### PR DESCRIPTION
## Summary
- add Questrade XLSX and IBKR CSV parsing for the ACB tool
- scope results by detected brokerage and add IBKR account type marking for consolidated statements
- add focused parser and account type marker coverage

## Tests
- npm test -- --run src/utils/acb/parser.test.ts src/components/acb/AccountTypeMarker.test.tsx
- npm run typecheck
- npm run lint